### PR TITLE
Changed 'shell' to 'electron.shell'

### DIFF
--- a/lib/p5js-snippets.js
+++ b/lib/p5js-snippets.js
@@ -5,7 +5,7 @@ import { CompositeDisposable } from 'atom'
 // Load Shell, fs and path for launching
 // external website urls, and loading json
 // files with all the references
-shell = require('shell');
+electron = require('electron')
 fs = require('fs');
 path = require('path');
 
@@ -100,10 +100,10 @@ export default {
 
   fetch() {
     let self = this;
-    shell.openExternal(self.referenceUrl);
+    electron.shell.openExternal(self.referenceUrl);
   },
 
   ref(){
-    shell.openExternal('https://p5js.org/reference/');
+    electron.shell.openExternal('https://p5js.org/reference/');
   }
 };


### PR DESCRIPTION
Looked around a bit to see what other packages are using and saw `electron.shell.openExternal` gave it a try and it seems to work.
This should fix #20